### PR TITLE
Added controller for ArticlePage

### DIFF
--- a/src/Controllers/ArticlePageController.php
+++ b/src/Controllers/ArticlePageController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TheWebmen\Articles\Controllers;
+
+use TheWebmen\Articles\Pages\ArticlePage;
+
+/**
+ * Class ArticlePageController
+ * @package TheWebmen\Articles\Controllers
+ *
+ * @method ArticlePage data()
+ */
+class ArticlePageController extends \PageController
+{
+
+}

--- a/src/Pages/ArticlePage.php
+++ b/src/Pages/ArticlePage.php
@@ -12,6 +12,7 @@ use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\TagField\TagField;
+use TheWebmen\Articles\Controllers\ArticlesPageController;
 use TheWebmen\Articles\Models\Author;
 use TheWebmen\Articles\Models\Tag;
 
@@ -194,6 +195,11 @@ class ArticlePage extends \Page
         );
 
         return $fields;
+    }
+
+    public function getControllerName(): string
+    {
+        return ArticlesPageController::class;
     }
 
     protected function onBeforeWrite()


### PR DESCRIPTION
This MR adds some controller for the ArticlePage.

Right now, this controller is just empty. But we've decided to add it already, so we can extend from this controller.

This way, if some Model extends `ArticlePage`, we can extend the controller from `ArticlePageController`.
This way we always extend from the module's controller, so if the controller gets logic later, that logic is directly available for the classes that extends this controller.